### PR TITLE
Use jsx plugin

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,5 @@
 System.config({
+  "baseURL": "/",
   "paths": {
     "*": "*.js",
     "app/*": "lib/*.js",
@@ -10,98 +11,390 @@ System.config({
 System.config({
   "map": {
     "bootstrap": "github:twbs/bootstrap@3.3.1",
+    "jsx": "github:floatdrop/plugin-jsx@1.1.0",
     "react": "npm:react@0.12.2",
+    "github:floatdrop/plugin-jsx@1.1.0": {
+      "react-tools": "npm:react-tools@0.13.3"
+    },
+    "github:jspm/nodelibs-assert@0.1.0": {
+      "assert": "npm:assert@1.3.0"
+    },
     "github:jspm/nodelibs-buffer@0.1.0": {
-      "buffer": "npm:buffer@3.0.1"
+      "buffer": "npm:buffer@3.2.2"
     },
-    "github:jspm/nodelibs-events@0.1.0": {
-      "events-browserify": "npm:events-browserify@0.0.1"
+    "github:jspm/nodelibs-constants@0.1.0": {
+      "constants-browserify": "npm:constants-browserify@0.0.1"
     },
-    "github:jspm/nodelibs-fs@0.1.0": {
-      "assert": "npm:assert@1.3.0",
-      "fs": "github:jspm/nodelibs-fs@0.1.0"
+    "github:jspm/nodelibs-crypto@0.1.0": {
+      "crypto-browserify": "npm:crypto-browserify@3.9.14"
+    },
+    "github:jspm/nodelibs-events@0.1.1": {
+      "events": "npm:events@1.0.2"
+    },
+    "github:jspm/nodelibs-http@1.7.1": {
+      "Base64": "npm:Base64@0.2.1",
+      "events": "github:jspm/nodelibs-events@0.1.1",
+      "inherits": "npm:inherits@2.0.1",
+      "stream": "github:jspm/nodelibs-stream@0.1.0",
+      "url": "github:jspm/nodelibs-url@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
     },
     "github:jspm/nodelibs-path@0.1.0": {
       "path-browserify": "npm:path-browserify@0.0.0"
     },
-    "github:jspm/nodelibs-process@0.1.0": {
-      "process": "npm:process@0.10.0"
+    "github:jspm/nodelibs-process@0.1.1": {
+      "process": "npm:process@0.10.1"
     },
     "github:jspm/nodelibs-stream@0.1.0": {
       "stream-browserify": "npm:stream-browserify@1.0.0"
     },
+    "github:jspm/nodelibs-string_decoder@0.1.0": {
+      "string_decoder": "npm:string_decoder@0.10.31"
+    },
+    "github:jspm/nodelibs-url@0.1.0": {
+      "url": "npm:url@0.10.3"
+    },
     "github:jspm/nodelibs-util@0.1.0": {
       "util": "npm:util@0.10.3"
+    },
+    "github:jspm/nodelibs-vm@0.1.0": {
+      "vm-browserify": "npm:vm-browserify@0.0.4"
     },
     "github:twbs/bootstrap@3.3.1": {
       "css": "github:systemjs/plugin-css@0.1.0",
       "jquery": "github:components/jquery@2.1.3"
     },
     "npm:amdefine@0.1.0": {
-      "fs": "github:jspm/nodelibs-fs@0.1.0",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "module": "github:jspm/nodelibs-module@0.1.0",
       "path": "github:jspm/nodelibs-path@0.1.0",
-      "process": "github:jspm/nodelibs-process@0.1.0"
+      "process": "github:jspm/nodelibs-process@0.1.1"
+    },
+    "npm:asn1.js@2.0.3": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "bn.js": "npm:bn.js@2.0.5",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "inherits": "npm:inherits@2.0.1",
+      "minimalistic-assert": "npm:minimalistic-assert@1.0.0",
+      "vm": "github:jspm/nodelibs-vm@0.1.0"
     },
     "npm:assert@1.3.0": {
       "util": "npm:util@0.10.3"
     },
-    "npm:buffer@3.0.1": {
+    "npm:ast-types@0.6.16": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:browserify-aes@1.0.1": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "create-hash": "npm:create-hash@1.1.1",
+      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "inherits": "npm:inherits@2.0.1",
+      "stream": "github:jspm/nodelibs-stream@0.1.0",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.0"
+    },
+    "npm:browserify-rsa@2.0.1": {
+      "bn.js": "npm:bn.js@2.0.5",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "constants": "github:jspm/nodelibs-constants@0.1.0",
+      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
+      "randombytes": "npm:randombytes@2.0.1"
+    },
+    "npm:browserify-sign@3.0.2": {
+      "bn.js": "npm:bn.js@2.0.5",
+      "browserify-rsa": "npm:browserify-rsa@2.0.1",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "create-hash": "npm:create-hash@1.1.1",
+      "create-hmac": "npm:create-hmac@1.1.3",
+      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
+      "elliptic": "npm:elliptic@3.0.3",
+      "inherits": "npm:inherits@2.0.1",
+      "parse-asn1": "npm:parse-asn1@3.0.1",
+      "stream": "github:jspm/nodelibs-stream@0.1.0",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.0"
+    },
+    "npm:buffer@3.2.2": {
       "base64-js": "npm:base64-js@0.0.8",
-      "ieee754": "npm:ieee754@1.1.4",
+      "ieee754": "npm:ieee754@1.1.5",
       "is-array": "npm:is-array@1.0.1"
+    },
+    "npm:commander@2.5.1": {
+      "child_process": "github:jspm/nodelibs-child_process@0.1.0",
+      "events": "github:jspm/nodelibs-events@0.1.1",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.1"
+    },
+    "npm:commoner@0.10.1": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "child_process": "github:jspm/nodelibs-child_process@0.1.0",
+      "commander": "npm:commander@2.5.1",
+      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
+      "events": "github:jspm/nodelibs-events@0.1.1",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "glob": "npm:glob@4.2.2",
+      "graceful-fs": "npm:graceful-fs@3.0.8",
+      "iconv-lite": "npm:iconv-lite@0.4.10",
+      "install": "npm:install@0.1.8",
+      "mkdirp": "npm:mkdirp@0.5.1",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "private": "npm:private@0.1.6",
+      "process": "github:jspm/nodelibs-process@0.1.1",
+      "q": "npm:q@1.1.2",
+      "recast": "npm:recast@0.9.18",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.0"
+    },
+    "npm:constants-browserify@0.0.1": {
+      "systemjs-json": "github:systemjs/plugin-json@0.1.0"
     },
     "npm:core-util-is@1.0.1": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0"
     },
+    "npm:create-ecdh@2.0.1": {
+      "bn.js": "npm:bn.js@2.0.5",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
+      "elliptic": "npm:elliptic@3.0.3"
+    },
+    "npm:create-hash@1.1.1": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "inherits": "npm:inherits@2.0.1",
+      "ripemd160": "npm:ripemd160@1.0.1",
+      "sha.js": "npm:sha.js@2.4.1",
+      "stream": "github:jspm/nodelibs-stream@0.1.0"
+    },
+    "npm:create-hmac@1.1.3": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "create-hash": "npm:create-hash@1.1.1",
+      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
+      "inherits": "npm:inherits@2.0.1",
+      "stream": "github:jspm/nodelibs-stream@0.1.0"
+    },
+    "npm:crypto-browserify@3.9.14": {
+      "browserify-aes": "npm:browserify-aes@1.0.1",
+      "browserify-sign": "npm:browserify-sign@3.0.2",
+      "create-ecdh": "npm:create-ecdh@2.0.1",
+      "create-hash": "npm:create-hash@1.1.1",
+      "create-hmac": "npm:create-hmac@1.1.3",
+      "diffie-hellman": "npm:diffie-hellman@3.0.2",
+      "inherits": "npm:inherits@2.0.1",
+      "pbkdf2": "npm:pbkdf2@3.0.4",
+      "public-encrypt": "npm:public-encrypt@2.0.1",
+      "randombytes": "npm:randombytes@2.0.1"
+    },
+    "npm:diffie-hellman@3.0.2": {
+      "bn.js": "npm:bn.js@2.0.5",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
+      "miller-rabin": "npm:miller-rabin@2.0.1",
+      "randombytes": "npm:randombytes@2.0.1",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.0"
+    },
+    "npm:elliptic@3.0.3": {
+      "bn.js": "npm:bn.js@2.0.5",
+      "brorand": "npm:brorand@1.0.5",
+      "hash.js": "npm:hash.js@1.0.3",
+      "inherits": "npm:inherits@2.0.1",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.0"
+    },
     "npm:envify@3.2.0": {
       "jstransform": "npm:jstransform@7.0.0",
-      "process": "github:jspm/nodelibs-process@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.1",
       "through": "npm:through@2.3.6"
     },
-    "npm:esprima-fb@7001.1.0-dev-harmony-fb": {
-      "fs": "github:jspm/nodelibs-fs@0.1.0",
-      "process": "github:jspm/nodelibs-process@0.1.0"
+    "npm:esprima-fb@10001.1.0-dev-harmony-fb": {
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "process": "github:jspm/nodelibs-process@0.1.1"
     },
-    "npm:events-browserify@0.0.1": {
-      "process": "github:jspm/nodelibs-process@0.1.0"
+    "npm:esprima-fb@13001.1001.0-dev-harmony-fb": {
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "process": "github:jspm/nodelibs-process@0.1.1"
+    },
+    "npm:esprima-fb@7001.1.0-dev-harmony-fb": {
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "process": "github:jspm/nodelibs-process@0.1.1"
+    },
+    "npm:glob@4.2.2": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "events": "github:jspm/nodelibs-events@0.1.1",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "inflight": "npm:inflight@1.0.4",
+      "inherits": "npm:inherits@2.0.1",
+      "minimatch": "npm:minimatch@1.0.0",
+      "once": "npm:once@1.3.2",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.1",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:graceful-fs@3.0.8": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "constants": "github:jspm/nodelibs-constants@0.1.0",
+      "module": "github:jspm/nodelibs-module@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.1",
+      "util": "github:jspm/nodelibs-util@0.1.0",
+      "vm": "github:jspm/nodelibs-vm@0.1.0"
+    },
+    "npm:hash.js@1.0.3": {
+      "inherits": "npm:inherits@2.0.1"
+    },
+    "npm:iconv-lite@0.4.10": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.1",
+      "stream": "github:jspm/nodelibs-stream@0.1.0",
+      "string_decoder": "github:jspm/nodelibs-string_decoder@0.1.0",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.0"
+    },
+    "npm:inflight@1.0.4": {
+      "once": "npm:once@1.3.2",
+      "process": "github:jspm/nodelibs-process@0.1.1",
+      "wrappy": "npm:wrappy@1.0.1"
     },
     "npm:inherits@2.0.1": {
       "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:install@0.1.8": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.1"
+    },
+    "npm:jstransform@10.1.0": {
+      "base62": "npm:base62@0.1.1",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "esprima-fb": "npm:esprima-fb@13001.1001.0-dev-harmony-fb",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "process": "github:jspm/nodelibs-process@0.1.1",
+      "source-map": "npm:source-map@0.1.31"
     },
     "npm:jstransform@7.0.0": {
       "base62": "npm:base62@0.1.1",
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "esprima-fb": "npm:esprima-fb@7001.1.0-dev-harmony-fb",
-      "process": "github:jspm/nodelibs-process@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.1",
       "source-map": "npm:source-map@0.1.31"
     },
+    "npm:miller-rabin@2.0.1": {
+      "bn.js": "npm:bn.js@2.0.5",
+      "brorand": "npm:brorand@1.0.5"
+    },
+    "npm:minimatch@1.0.0": {
+      "lru-cache": "npm:lru-cache@2.6.4",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.1",
+      "sigmund": "npm:sigmund@1.0.1"
+    },
+    "npm:mkdirp@0.5.1": {
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "minimist": "npm:minimist@0.0.8",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.1"
+    },
+    "npm:once@1.3.2": {
+      "wrappy": "npm:wrappy@1.0.1"
+    },
+    "npm:parse-asn1@3.0.1": {
+      "asn1.js": "npm:asn1.js@2.0.3",
+      "browserify-aes": "npm:browserify-aes@1.0.1",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "create-hash": "npm:create-hash@1.1.1",
+      "pbkdf2": "npm:pbkdf2@3.0.4",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.0"
+    },
     "npm:path-browserify@0.0.0": {
-      "process": "github:jspm/nodelibs-process@0.1.0"
+      "process": "github:jspm/nodelibs-process@0.1.1"
+    },
+    "npm:pbkdf2@3.0.4": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "child_process": "github:jspm/nodelibs-child_process@0.1.0",
+      "create-hmac": "npm:create-hmac@1.1.3",
+      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.1",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.0"
+    },
+    "npm:public-encrypt@2.0.1": {
+      "bn.js": "npm:bn.js@2.0.5",
+      "browserify-rsa": "npm:browserify-rsa@2.0.1",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "create-hash": "npm:create-hash@1.1.1",
+      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
+      "parse-asn1": "npm:parse-asn1@3.0.1",
+      "randombytes": "npm:randombytes@2.0.1"
+    },
+    "npm:punycode@1.3.2": {
+      "process": "github:jspm/nodelibs-process@0.1.1"
+    },
+    "npm:q@1.1.2": {
+      "process": "github:jspm/nodelibs-process@0.1.1"
+    },
+    "npm:randombytes@2.0.1": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.1"
+    },
+    "npm:react-tools@0.13.3": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "commoner": "npm:commoner@0.10.1",
+      "jstransform": "npm:jstransform@10.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.1"
     },
     "npm:react@0.12.2": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "envify": "npm:envify@3.2.0",
-      "process": "github:jspm/nodelibs-process@0.1.0"
+      "process": "github:jspm/nodelibs-process@0.1.1"
     },
     "npm:readable-stream@1.1.13": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "core-util-is": "npm:core-util-is@1.0.1",
-      "events": "github:jspm/nodelibs-events@0.1.0",
+      "events": "github:jspm/nodelibs-events@0.1.1",
       "inherits": "npm:inherits@2.0.1",
       "isarray": "npm:isarray@0.0.1",
-      "process": "github:jspm/nodelibs-process@0.1.0",
-      "stream": "npm:stream-browserify@1.0.0",
+      "process": "github:jspm/nodelibs-process@0.1.1",
+      "stream": "github:jspm/nodelibs-stream@0.1.0",
+      "stream-browserify": "npm:stream-browserify@1.0.0",
       "string_decoder": "npm:string_decoder@0.10.31",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:recast@0.9.18": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "ast-types": "npm:ast-types@0.6.16",
+      "esprima-fb": "npm:esprima-fb@10001.1.0-dev-harmony-fb",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "private": "npm:private@0.1.6",
+      "process": "github:jspm/nodelibs-process@0.1.1",
+      "source-map": "npm:source-map@0.1.43"
+    },
+    "npm:ripemd160@1.0.1": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.1"
+    },
+    "npm:sha.js@2.4.1": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "inherits": "npm:inherits@2.0.1",
+      "process": "github:jspm/nodelibs-process@0.1.1"
+    },
+    "npm:sigmund@1.0.1": {
+      "http": "github:jspm/nodelibs-http@1.7.1",
       "util": "github:jspm/nodelibs-util@0.1.0"
     },
     "npm:source-map@0.1.31": {
       "amdefine": "npm:amdefine@0.1.0",
-      "fs": "github:jspm/nodelibs-fs@0.1.0",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
       "path": "github:jspm/nodelibs-path@0.1.0",
-      "process": "github:jspm/nodelibs-process@0.1.0"
+      "process": "github:jspm/nodelibs-process@0.1.1"
+    },
+    "npm:source-map@0.1.43": {
+      "amdefine": "npm:amdefine@0.1.0",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.1"
     },
     "npm:stream-browserify@1.0.0": {
-      "events": "github:jspm/nodelibs-events@0.1.0",
+      "events": "github:jspm/nodelibs-events@0.1.1",
       "inherits": "npm:inherits@2.0.1",
       "readable-stream": "npm:readable-stream@1.1.13"
     },
@@ -109,12 +402,21 @@ System.config({
       "buffer": "github:jspm/nodelibs-buffer@0.1.0"
     },
     "npm:through@2.3.6": {
-      "process": "github:jspm/nodelibs-process@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.1",
       "stream": "github:jspm/nodelibs-stream@0.1.0"
+    },
+    "npm:url@0.10.3": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "punycode": "npm:punycode@1.3.2",
+      "querystring": "npm:querystring@0.2.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
     },
     "npm:util@0.10.3": {
       "inherits": "npm:inherits@2.0.1",
-      "process": "github:jspm/nodelibs-process@0.1.0"
+      "process": "github:jspm/nodelibs-process@0.1.1"
+    },
+    "npm:vm-browserify@0.0.4": {
+      "indexof": "npm:indexof@0.0.1"
     }
   }
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,8 +13,7 @@ var karma = require('karma').server;
 /*
 * 1. Setup a webserver with livereload using BrowserSync
 * 2. JS and CSS get processed and served from the 'build' folder
-* 3. JSX: Transform jsx React files and put in build 'build' folder
-* 4. Compile sass files, autoprefix and put in 'build' folder
+* 3. Compile sass files, autoprefix and put in 'build' folder
 * */
 
  // BrowserSync Server
@@ -36,10 +35,9 @@ gulp.task('browser-sync', function() {
 });
 
 // JSX
-gulp.task('jsx', function() {
+gulp.task('js', function() {
   return gulp.src('src/**/*.js')
-    .pipe(plugins.cached('jsx'))  //Process only changed files
-    .pipe(plugins.react())
+    .pipe(plugins.cached('js'))  //Process only changed files
     .pipe(gulp.dest('build/'));
 });
 
@@ -60,7 +58,7 @@ gulp.task('sass', function() {
 });
 
 // serve task
-gulp.task('serve', ['browser-sync', 'jsx', 'sass'] , function(cb) {
+gulp.task('serve', ['browser-sync', 'js', 'sass'] , function(cb) {
 
   plugins.watch(
     './src/sass/**/*.scss',
@@ -78,7 +76,7 @@ gulp.task('serve', ['browser-sync', 'jsx', 'sass'] , function(cb) {
       name: 'JS'
     },
     function() {
-      gulp.start('jsx');
+      gulp.start('js');
     }
   );
 });
@@ -91,7 +89,7 @@ gulp.task('delete-build', function() {
 });
 
 //build (no server)
-gulp.task('build', ['jsx', 'sass']);
+gulp.task('build', ['js', 'sass']);
 
 // Default
 gulp.task('default', ['serve']);
@@ -132,8 +130,8 @@ gulp.task('html', function() {
 });
 
 // Bundle with jspm
-gulp.task('bundle', ['jsx'], plugins.shell.task([
-  'jspm bundle-sfx build/js/main dist/js/app.js'
+gulp.task('bundle', ['js'], plugins.shell.task([
+  'jspm bundle-sfx build/js/main.js!jsx dist/js/app.js'
 ]));
 
 // Uglify the bundle

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
 <script src="jspm_packages/system.js"></script>
 <script src="config.js"></script>
 <script>
-  System.import('build/js/main');
+  System.import('build/js/main.js!jsx');
 </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "jspm": {
     "dependencies": {
-      "bootstrap": "^3.3.1",
-      "react": "^0.12.2"
+      "bootstrap": "github:twbs/bootstrap@^3.3.1",
+      "jsx": "github:floatdrop/plugin-jsx@^1.1.0",
+      "react": "npm:react@^0.12.2"
     }
   },
   "devDependencies": {
@@ -13,7 +14,6 @@
     "gulp-csso": "^0.2.9",
     "gulp-inject": "^1.1.1",
     "gulp-load-plugins": "^0.8.0",
-    "gulp-react": "^2.0.0",
     "gulp-rename": "^1.2.0",
     "gulp-sass": "^1.2.4",
     "gulp-shell": "^0.2.11",

--- a/src/js/components/Feed.js
+++ b/src/js/components/Feed.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import FeedList from './FeedList';
-import FeedForm from './FeedForm';
-import ShowAddButton from './ShowAddButton';
+import FeedList from './FeedList.js!jsx';
+import FeedForm from './FeedForm.js!jsx';
+import ShowAddButton from './ShowAddButton.js!jsx';
 
 var Feed = React.createClass({
 

--- a/src/js/components/FeedList.js
+++ b/src/js/components/FeedList.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import FeedItem from './FeedItem';
+import FeedItem from './FeedItem.js!jsx';
 
 var FeedList = React.createClass({
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -2,6 +2,6 @@
 'use strict';
 
 import React from 'react';
-import Feed from './components/Feed';
+import Feed from './components/Feed.js!jsx';
 
 React.render(<Feed />, document.getElementById('app'));

--- a/test/sample.spec.js
+++ b/test/sample.spec.js
@@ -2,7 +2,7 @@
 'use strict';
 
 import React from 'react';
-import Feed from '../build/js/components/Feed';
+import Feed from '../build/js/components/Feed.js!jsx';
 
 describe('A test suite', function() {
 


### PR DESCRIPTION
This should close #1. 

Here's basically what I did:
- [x] Remove gulp-react in favor of the jspm-specific plugin [floatdrop/plugin-jsx.](https://github.com/floatdrop/plugin-jsx).
- [x] Import references by using the `.js!jsx` syntax.
- [x] Reconfigure gulp to not precompile react.

The `tests` and `dist` commands work with these changes.
