### PR TITLE
Upgrading babel fixes the error TypeError: Cannot read property 'suppressDeprecationMessages' of undefined when running gulp dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
       "react": "npm:react@^0.13.3"
     },
     "devDependencies": {
-      "babel": "npm:babel-core@^5.6.15",
-      "babel-runtime": "npm:babel-runtime@^5.1.13",
-      "core-js": "npm:core-js@^0.9.4"
+      "babel": "npm:babel-core@^5.8.24",
+      "babel-runtime": "npm:babel-runtime@^5.8.24",
+      "core-js": "npm:core-js@^1.1.4"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrading babel fixes the error `TypeError: Cannot read property
'suppressDeprecationMessages' of undefined` when running `gulp dist`

Fixes  tinkertrain/jspm-react#10
