### PR TITLE
Make functioning build with 'gulp dist'

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -45,8 +45,9 @@ export default {
   },
 
   htmlReplace: {
-    'js': ['js/bundle.js', 'js/system.js', 'js/config.js'],
-    'css': 'css/bundle.css'
+    'js': ['js/system.js', 'js/config.js', 'js/bundle.js'],
+    'css': 'css/bundle.css',
+    'entry_point': '<script> System.import("src/app.js"); </script>'
   },
 
   handleError: gutil.log,

--- a/index.html
+++ b/index.html
@@ -19,5 +19,8 @@
     </script>
     <!-- endbuild -->
 
+    <!-- build:entry_point-->
+    <!-- endbuild -->
+
   </body>
 </html>


### PR DESCRIPTION
'gulp dist' was not building a functioning distribution. System.js wasn't found and there was no executable entry point to the rest of the app.

To fix this, I:
- Changed the order of the htmlReplace js parameters, to put 'js/system.js' at the top.
- Added a new  htmlReplace block, to add an entry point to 'src/app.js' in index.html

Perhaps this is better solved by flagging the app.js file as a --script, instead of a --module, but I did not know how to do that.
